### PR TITLE
Features/expose to queryable

### DIFF
--- a/src/MongoDB.Generators/MongoDB.Generators.csproj
+++ b/src/MongoDB.Generators/MongoDB.Generators.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;IdGenerators;Id Generators;id-generators</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
+++ b/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
+++ b/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
@@ -16,14 +16,14 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />
   </ItemGroup>
 

--- a/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
+++ b/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
+++ b/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository.Abstractions/IMongoDbRepository.cs
+++ b/src/MongoDB.Repository.Abstractions/IMongoDbRepository.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using MongoDB.Driver.Linq;
+using MongoDB.QueryBuilder;
+using System;
 
 namespace MongoDB.Repository
 {
@@ -6,5 +8,8 @@ namespace MongoDB.Repository
     { }
 
     public interface IMongoDbRepository<T> : IMongoDbRepository, ISyncMongoDbRepository<T>, IAsyncMongoDbRepository<T>, IDisposable where T : class
-    { }
+    {
+        IMongoQueryable<T> ToQueryable(IMongoDbQuery<T> query);
+        IMongoQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query);
+    }
 }

--- a/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
+++ b/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository/MongoDB.Repository.csproj
+++ b/src/MongoDB.Repository/MongoDB.Repository.csproj
@@ -16,12 +16,12 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MongoDB.Repository/MongoDbRepository.cs
+++ b/src/MongoDB.Repository/MongoDbRepository.cs
@@ -982,9 +982,9 @@ namespace MongoDB.Repository
 
         #endregion IAsyncRepository<T> Members
 
-        #region Private Methods
+        #region IMongoDbRepository<T> Members
 
-        private IMongoQueryable<T> ToQueryable(IMongoDbQuery<T> query)
+        public IMongoQueryable<T> ToQueryable(IMongoDbQuery<T> query)
         {
             IMongoDbMultipleResultQuery<T> multipleResultQuery = null;
 
@@ -1035,7 +1035,7 @@ namespace MongoDB.Repository
             return (IMongoQueryable<T>)queryable;
         }
 
-        private IMongoQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query)
+        public IMongoQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query)
         {
             IMongoDbMultipleResultQuery<T, TResult> multipleResultQuery = null;
 
@@ -1081,7 +1081,7 @@ namespace MongoDB.Repository
             return (IMongoQueryable<TResult>)queryable.Select(query.Selector);
         }
 
-        #endregion Private Methods
+        #endregion IMongoDbRepository<T> Members
 
         #region IDisposable Members
 

--- a/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
+++ b/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
+++ b/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Hello Fer

At first, I want to recognize your nice work in this package.

I created this PR to your consideration:
- Exposing toQueryable, I needed to use OData to concatenate queries to an existing queryable see the following example:

```
public Task<DecisionProgramDto> SearchProgram(ODataQueryOptions<DecisionProgram> oquery)
        {
            var repo = _uow.Repository<DecisionProgramInfo>();
            var query = repo.MultipleResultQuery()
                            .AndFilter(p => p.Deleted != true);

            var queriable = repo.ToQueryable(query);

            var programInfoList = oquery.ApplyTo(queriable);

            var programList = _mapper.Map<IList<DecisionProgramDto>>(programInfoList);

            ...
        }
```

- My second commit is to bump the version 1.2.2 and downgrade few dependencies from 7.0.x to 6.0.0, in this case I didn't see any specific requirement why to enforce the new version 7 instead of 6, keeping 6.0.0 will maintain compatibility with previous uses, my recommendation is to keep 6.0.0 unless you have to use an specific feature of version 7.0.0.  Also you always can have an updated package (7.0.0) in the project where you include your nuget, but if you make 7.0.0 as required in your package will tell everyone that you require this version to work, which is not really necessary. 

