### PR TITLE
feat: adds methods to updateMany and bulkWrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,6 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /tests/MongoDB.Tests/docker/.data
+
+# VSCode
+.vscode

--- a/README.md
+++ b/README.md
@@ -264,6 +264,18 @@ public void DeleteBlog()
 
     _unitOfWork.SaveChanges();
 }
+
+public void UpdateManyBlogs()
+{
+    var repository = _unitOfWork.Repository<Blog>();
+    
+    var filter = Builders<Blog>.Filter.In(b => b.Id, blogsId);
+    var update = Builders<Blog>.Update.Set(b => b.Title, "updated-title");
+            
+    repository.UpdateMany(filter, update);
+
+    _unitOfWork.SaveChanges();
+}
 ```
 
 The operations above are also available as async.

--- a/README.md
+++ b/README.md
@@ -12,32 +12,32 @@ If you like or are using this project to learn or start your solution, please gi
 
  | Package | NuGet |
  | ------- | ------- |
- | MongoDB.Data.Infrastructure.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure.Abstractions/1.2.5) |
- | MongoDB.Data.QueryBuilder.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder.Abstractions/1.2.5) |
- | MongoDB.Data.Repository.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Repository.Abstractions/1.2.5) |
- | MongoDB.Data.UnitOfWork.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork.Abstractions/1.2.5) |
+ | MongoDB.Data.Infrastructure.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure.Abstractions/1.3.0) |
+ | MongoDB.Data.QueryBuilder.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder.Abstractions/1.3.0) |
+ | MongoDB.Data.Repository.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Repository.Abstractions/1.3.0) |
+ | MongoDB.Data.UnitOfWork.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork.Abstractions/1.3.0) |
  | ------- | ------- |
- | MongoDB.Data.Generators | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Generators)](https://www.nuget.org/packages/MongoDB.Data.Generators/1.2.5) |
- | MongoDB.Data.Infrastructure | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure/1.2.5) |
- | MongoDB.Data.QueryBuilder | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder/1.2.5) |
- | MongoDB.Data.Repository | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository)](https://www.nuget.org/packages/MongoDB.Data.Repository/1.2.5) |
- | MongoDB.Data.UnitOfWork | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork/1.2.5) |
+ | MongoDB.Data.Generators | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Generators)](https://www.nuget.org/packages/MongoDB.Data.Generators/1.3.0) |
+ | MongoDB.Data.Infrastructure | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure/1.3.0) |
+ | MongoDB.Data.QueryBuilder | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder/1.3.0) |
+ | MongoDB.Data.Repository | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository)](https://www.nuget.org/packages/MongoDB.Data.Repository/1.3.0) |
+ | MongoDB.Data.UnitOfWork | [![Nuget](https://img.shields.io/badge/nuget-v1.2.5-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork/1.3.0) |
 
 ## Installation
 
 MongoDB.DataAccess is available on Nuget.
 
 ```
-Install-Package MongoDB.Data.Infrastructure.Abstractions -Version 1.2.5
-Install-Package MongoDB.Data.QueryBuilder.Abstractions -Version 1.2.5
-Install-Package MongoDB.Data.Repository.Abstractions -Version 1.2.5
-Install-Package MongoDB.Data.UnitOfWork.Abstractions -Version 1.2.5
+Install-Package MongoDB.Data.Infrastructure.Abstractions -Version 1.3.0
+Install-Package MongoDB.Data.QueryBuilder.Abstractions -Version 1.3.0
+Install-Package MongoDB.Data.Repository.Abstractions -Version 1.3.0
+Install-Package MongoDB.Data.UnitOfWork.Abstractions -Version 1.3.0
 
-Install-Package MongoDB.Data.Generators -Version 1.2.5
-Install-Package MongoDB.Data.Infrastructure -Version 1.2.5
-Install-Package MongoDB.Data.QueryBuilder -Version 1.2.5
-Install-Package MongoDB.Data.Repository -Version 1.2.5
-Install-Package MongoDB.Data.UnitOfWork -Version 1.2.5
+Install-Package MongoDB.Data.Generators -Version 1.3.0
+Install-Package MongoDB.Data.Infrastructure -Version 1.3.0
+Install-Package MongoDB.Data.QueryBuilder -Version 1.3.0
+Install-Package MongoDB.Data.Repository -Version 1.3.0
+Install-Package MongoDB.Data.UnitOfWork -Version 1.3.0
 ```
 
 **P.S.: MongoDB.Data.UnitOfWork depends on the other packages, so installing this package is enough.**

--- a/README.md
+++ b/README.md
@@ -276,6 +276,23 @@ public void UpdateManyBlogs()
 
     _unitOfWork.SaveChanges();
 }
+
+public void BulkWriteBlogs()
+{
+    var repository = _unitOfWork.Repository<Blog>();
+    
+    var requests = new List<WriteModel<Blog>>();
+    foreach (var blogId in blogsId)
+    {
+        var filter = Builders<Blog>.Filter.Eq(b => b.Id, blogId);
+        var update = Builders<Blog>.Update.Set(b => b.Title, $"{updatedTitle}-{blogId}");
+        requests.Add(new UpdateOneModel<Blog>(filter, update));
+    }
+            
+    repository.BulkWrite(requests);
+
+    _unitOfWork.SaveChanges();
+}
 ```
 
 The operations above are also available as async.

--- a/src/MongoDB.Generators/MongoDB.Generators.csproj
+++ b/src/MongoDB.Generators/MongoDB.Generators.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;IdGenerators;Id Generators;id-generators</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
+++ b/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
+++ b/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
+++ b/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
+++ b/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository.Abstractions/IMongoDbAsyncRepository.cs
+++ b/src/MongoDB.Repository.Abstractions/IMongoDbAsyncRepository.cs
@@ -101,5 +101,11 @@ namespace MongoDB.Repository
             Expression<Func<T, bool>> predicate,
             DeleteOptions options = null,
             CancellationToken cancellationToken = default);
+
+        Task<object> UpdateManyAsync(
+            FilterDefinition<T> filter,
+	        UpdateDefinition<T> update,
+	        UpdateOptions options = null,
+	        CancellationToken cancellationToken = default);
     }
 }

--- a/src/MongoDB.Repository.Abstractions/IMongoDbAsyncRepository.cs
+++ b/src/MongoDB.Repository.Abstractions/IMongoDbAsyncRepository.cs
@@ -104,8 +104,13 @@ namespace MongoDB.Repository
 
         Task<object> UpdateManyAsync(
             FilterDefinition<T> filter,
-	        UpdateDefinition<T> update,
-	        UpdateOptions options = null,
-	        CancellationToken cancellationToken = default);
+            UpdateDefinition<T> update,
+            UpdateOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        Task<object> BulkWriteAsync(
+            IEnumerable<WriteModel<T>> requests,
+            BulkWriteOptions options = null,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/MongoDB.Repository.Abstractions/IMongoDbSyncRepository.cs
+++ b/src/MongoDB.Repository.Abstractions/IMongoDbSyncRepository.cs
@@ -38,6 +38,7 @@ namespace MongoDB.Repository
         object DeleteOne(Expression<Func<T, bool>> predicate, DeleteOptions options = null);
         object DeleteMany(Expression<Func<T, bool>> predicate, DeleteOptions options = null);
         object UpdateMany(FilterDefinition<T> filter, UpdateDefinition<T> update, UpdateOptions options = null);
+        object BulkWrite(IEnumerable<WriteModel<T>> requests, BulkWriteOptions options = null);
         IMongoQueryable<T> ToQueryable(IMongoDbQuery<T> query);
         IMongoQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query);
     }

--- a/src/MongoDB.Repository.Abstractions/IMongoDbSyncRepository.cs
+++ b/src/MongoDB.Repository.Abstractions/IMongoDbSyncRepository.cs
@@ -37,6 +37,7 @@ namespace MongoDB.Repository
         object ReplaceOne(Expression<Func<T, bool>> predicate, T entity, ReplaceOptions options = null);
         object DeleteOne(Expression<Func<T, bool>> predicate, DeleteOptions options = null);
         object DeleteMany(Expression<Func<T, bool>> predicate, DeleteOptions options = null);
+        object UpdateMany(FilterDefinition<T> filter, UpdateDefinition<T> update, UpdateOptions options = null);
         IMongoQueryable<T> ToQueryable(IMongoDbQuery<T> query);
         IMongoQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query);
     }

--- a/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
+++ b/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository/MongoDB.Repository.csproj
+++ b/src/MongoDB.Repository/MongoDB.Repository.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
+++ b/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
+++ b/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.2.5</Version>
+    <Version>1.3.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Hi @ffernandolima! As we talked this week, I'm adding methods to support updating of multiple documents.

* Adds **UpdateMany** and **UpdateManyAsync** methods that are responsible for updating all documents in the collection that match the filter
* Adds **BulkWrite** and **BulkWriteAsync** methods that take an array of write operations and execute each of them in order. They can be used to insert, update and delete multiple records