### PR TITLE
Multiple Contexts multiple Database Servers

### DIFF
--- a/samples/MongoDB.Data/BloggingContext.cs
+++ b/samples/MongoDB.Data/BloggingContext.cs
@@ -3,7 +3,7 @@ using MongoDB.Infrastructure;
 
 namespace MongoDB.Data
 {
-    public class BloggingContext : MongoDbContext
+    public class BloggingContext : MongoDbContext, IMongoDbContext<BloggingContext>
     {
         public BloggingContext(IMongoClient client, IMongoDatabase database, IMongoDbContextOptions options)
             : base(client, database, options)

--- a/samples/MongoDB.Data/PollContext.cs
+++ b/samples/MongoDB.Data/PollContext.cs
@@ -1,0 +1,12 @@
+﻿using MongoDB.Driver;
+using MongoDB.Infrastructure;
+
+namespace MongoDB.Data
+{
+    public class PollContext : MongoDbContext, IMongoDbContext<PollContext>
+    {
+        public PollContext(IMongoClient client, IMongoDatabase database, IMongoDbContextOptions options)
+            : base(client, database, options)
+        { }
+    }
+}

--- a/samples/MongoDB.WebAPI/appsettings.Development.json
+++ b/samples/MongoDB.WebAPI/appsettings.Development.json
@@ -9,8 +9,12 @@
 
   "ApplicationName": "MongoDB.WebAPI",
 
-  "MongoSettings": {
+  "MongoSettings1": {
     "ConnectionString": "mongodb://localhost:30001/",
+    "DatabaseName": "MongoDBDataAccess"
+  },
+  "MongoSettings2": {
+    "ConnectionString": "mongodb://localhost:30002/",
     "DatabaseName": "MongoDBDataAccess"
   }
 }

--- a/src/MongoDB.Infrastructure.Abstractions/IMongoDbContext.cs
+++ b/src/MongoDB.Infrastructure.Abstractions/IMongoDbContext.cs
@@ -10,4 +10,9 @@ namespace MongoDB.Infrastructure
         IClientSessionHandle Session { get; }
         IMongoDbContextOptions Options { get; }
     }
+
+    public interface IMongoDbContext<T> : IMongoDbContext where T : IMongoDbContext
+    {
+
+    }
 }

--- a/src/MongoDB.Infrastructure/Extensions/MongoDbInfrastructureServiceCollectionExtensions.cs
+++ b/src/MongoDB.Infrastructure/Extensions/MongoDbInfrastructureServiceCollectionExtensions.cs
@@ -17,7 +17,8 @@ namespace MongoDB.Infrastructure.Extensions
             MongoDbContextOptions dbContextOptions = null,
             MongoDbKeepAliveSettings keepAliveSettings = null,
             MongoDbFluentConfigurationOptions fluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -38,15 +39,26 @@ namespace MongoDB.Infrastructure.Extensions
 
             clientSettings.ConfigureCluster(keepAliveSettings);
 
-            services.TryAddSingleton<IMongoClient>(new MongoClient(clientSettings));
-            services.TryAddSingleton(provider =>
+            if (factory != null)
             {
-                var client = provider.GetRequiredService<IMongoClient>();
+                var client = new MongoClient(clientSettings);
                 var database = client.GetDatabase(databaseName, databaseSettings);
-                return database;
-            });
-            services.TryAddSingleton<IMongoDbContextOptions>(dbContextOptions ?? new MongoDbContextOptions(clientSettings));
-            services.TryAdd(new ServiceDescriptor(typeof(TService), typeof(TImplementation), serviceLifetime));
+                var options = new MongoDbContextOptions(clientSettings);
+                 
+                services.TryAdd(new ServiceDescriptor(typeof(TService), sp => factory(sp, client, database, options), serviceLifetime));
+            }
+            else
+            {
+                services.TryAddSingleton<IMongoClient>(new MongoClient(clientSettings));
+                services.TryAddSingleton(provider =>
+                {
+                    var client = provider.GetRequiredService<IMongoClient>();
+                    var database = client.GetDatabase(databaseName, databaseSettings);
+                    return database;
+                });
+                services.TryAddSingleton<IMongoDbContextOptions>(dbContextOptions ?? new MongoDbContextOptions(clientSettings));
+                services.TryAdd(new ServiceDescriptor(typeof(TService), typeof(TImplementation), serviceLifetime));                
+            }
 
             if (typeof(TService) != typeof(TImplementation))
             {
@@ -75,7 +87,8 @@ namespace MongoDB.Infrastructure.Extensions
             Action<MongoDbContextOptions> setupDbContextOptions = null,
             Action<MongoDbKeepAliveSettings> setupKeepAliveSettings = null,
             Action<MongoDbFluentConfigurationOptions> setupFluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -132,7 +145,8 @@ namespace MongoDB.Infrastructure.Extensions
                 dbContextOptions,
                 keepAliveSettings,
                 fluentConfigurationOptions,
-                serviceLifetime);
+                serviceLifetime,
+                factory);
 
             return services;
         }
@@ -145,7 +159,8 @@ namespace MongoDB.Infrastructure.Extensions
             MongoDbContextOptions dbContextOptions = null,
             MongoDbKeepAliveSettings keepAliveSettings = null,
             MongoDbFluentConfigurationOptions fluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -171,7 +186,8 @@ namespace MongoDB.Infrastructure.Extensions
                 dbContextOptions,
                 keepAliveSettings,
                 fluentConfigurationOptions,
-                serviceLifetime);
+                serviceLifetime,
+                factory);
 
             return services;
         }
@@ -184,7 +200,8 @@ namespace MongoDB.Infrastructure.Extensions
             Action<MongoDbContextOptions> setupDbContextOptions = null,
             Action<MongoDbKeepAliveSettings> setupKeepAliveSettings = null,
             Action<MongoDbFluentConfigurationOptions> setupFluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -240,7 +257,8 @@ namespace MongoDB.Infrastructure.Extensions
                 dbContextOptions,
                 keepAliveSettings,
                 fluentConfigurationOptions,
-                serviceLifetime);
+                serviceLifetime, 
+                factory);
 
             return services;
         }
@@ -253,7 +271,8 @@ namespace MongoDB.Infrastructure.Extensions
             MongoDbContextOptions dbContextOptions = null,
             MongoDbKeepAliveSettings keepAliveSettings = null,
             MongoDbFluentConfigurationOptions fluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -279,7 +298,8 @@ namespace MongoDB.Infrastructure.Extensions
                 dbContextOptions,
                 keepAliveSettings,
                 fluentConfigurationOptions,
-                serviceLifetime);
+                serviceLifetime,
+                factory);
 
             return services;
         }
@@ -292,7 +312,8 @@ namespace MongoDB.Infrastructure.Extensions
             Action<MongoDbContextOptions> setupDbContextOptions = null,
             Action<MongoDbKeepAliveSettings> setupKeepAliveSettings = null,
             Action<MongoDbFluentConfigurationOptions> setupFluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -334,7 +355,8 @@ namespace MongoDB.Infrastructure.Extensions
             MongoDbContextOptions dbContextOptions = null,
             MongoDbKeepAliveSettings keepAliveSettings = null,
             MongoDbFluentConfigurationOptions fluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -360,7 +382,8 @@ namespace MongoDB.Infrastructure.Extensions
                 dbContextOptions,
                 keepAliveSettings,
                 fluentConfigurationOptions,
-                serviceLifetime);
+                serviceLifetime,
+                factory);
 
             return services;
         }
@@ -373,7 +396,8 @@ namespace MongoDB.Infrastructure.Extensions
             Action<MongoDbContextOptions> setupDbContextOptions = null,
             Action<MongoDbKeepAliveSettings> setupKeepAliveSettings = null,
             Action<MongoDbFluentConfigurationOptions> setupFluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -429,7 +453,8 @@ namespace MongoDB.Infrastructure.Extensions
                 dbContextOptions,
                 keepAliveSettings,
                 fluentConfigurationOptions,
-                serviceLifetime);
+                serviceLifetime,
+                factory);
 
             return services;
         }
@@ -440,7 +465,8 @@ namespace MongoDB.Infrastructure.Extensions
             MongoDbContextOptions dbContextOptions = null,
             MongoDbKeepAliveSettings keepAliveSettings = null,
             MongoDbFluentConfigurationOptions fluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -475,7 +501,8 @@ namespace MongoDB.Infrastructure.Extensions
                     dbContextOptions,
                     keepAliveSettings,
                     fluentConfigurationOptions,
-                    serviceLifetime);
+                    serviceLifetime,
+                    factory);
             }
 
             if (connectionString is not null)
@@ -487,7 +514,8 @@ namespace MongoDB.Infrastructure.Extensions
                     dbContextOptions,
                     keepAliveSettings,
                     fluentConfigurationOptions,
-                    serviceLifetime);
+                    serviceLifetime, 
+                    factory);
             }
 
             return services;
@@ -499,7 +527,8 @@ namespace MongoDB.Infrastructure.Extensions
             Action<MongoDbContextOptions> setupDbContextOptions = null,
             Action<MongoDbKeepAliveSettings> setupKeepAliveSettings = null,
             Action<MongoDbFluentConfigurationOptions> setupFluentConfigurationOptions = null,
-            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped)
+            ServiceLifetime serviceLifetime = ServiceLifetime.Scoped,
+            Func<IServiceProvider, IMongoClient, IMongoDatabase, IMongoDbContextOptions, object> factory = null)
                 where TService : IMongoDbContext
                 where TImplementation : class, TService
         {
@@ -555,7 +584,8 @@ namespace MongoDB.Infrastructure.Extensions
                     dbContextOptions,
                     keepAliveSettings,
                     fluentConfigurationOptions,
-                    serviceLifetime);
+                    serviceLifetime,
+                    factory);
             }
 
             if (connectionString is not null)
@@ -567,7 +597,8 @@ namespace MongoDB.Infrastructure.Extensions
                     dbContextOptions,
                     keepAliveSettings,
                     fluentConfigurationOptions,
-                    serviceLifetime);
+                    serviceLifetime,
+                    factory);
             }
 
             return services;


### PR DESCRIPTION
Hello Fer,

I was dealing with an issue of how to connect to more than one database context in the same project, the way injection is done IMongoClient in shared and multiples IMongoDbContext is not natively allowed, I achieve this by creating a Generic version of IMongoDbContext<T> and adding a factory method to the DI Extensions so we can build the context.

This implementation is backward compatible, if we only have only one  context/db registered the code doesn't change but if we want to use more than one context we now can by using IMongoDbContext<>.

Please let me know if you find an issue with this implementation, or if you have another idea about how to handle this situation of having multiples contexts/database servers.

I updated the example by including a new context just with the purpose you can check now each context pick the proper database configuration.