### PR TITLE
Features/allow clients diff by credentials

### DIFF
--- a/src/MongoDB.Infrastructure/Internal/MongoDbClientManager.cs
+++ b/src/MongoDB.Infrastructure/Internal/MongoDbClientManager.cs
@@ -39,6 +39,7 @@ namespace MongoDB.Infrastructure.Internal
         private bool TryGet(MongoClientSettings clientSettings, out IMongoClient client)
         {
             client = _clients.Where(client => client is not null)
+                             .Where(client => client.Settings.Credential == clientSettings.Credential)
                              .Where(client => client.Settings.Servers.Count() == clientSettings.Servers.Count())
                              .Where(client => client.Settings.Servers.All(clientSettings.Servers.Contains))
                              .SingleOrDefault();

--- a/src/MongoDB.Infrastructure/Internal/MongoDbClientManager.cs
+++ b/src/MongoDB.Infrastructure/Internal/MongoDbClientManager.cs
@@ -39,6 +39,7 @@ namespace MongoDB.Infrastructure.Internal
         private bool TryGet(MongoClientSettings clientSettings, out IMongoClient client)
         {
             client = _clients.Where(client => client is not null)
+                             .Where(client => client.Settings.ToString() == clientSettings.ToString())
                              .Where(client => client.Settings.Servers.Count() == clientSettings.Servers.Count())
                              .Where(client => client.Settings.Servers.All(clientSettings.Servers.Contains))
                              .SingleOrDefault();

--- a/src/MongoDB.Infrastructure/Internal/MongoDbDatabaseManager.cs
+++ b/src/MongoDB.Infrastructure/Internal/MongoDbDatabaseManager.cs
@@ -44,6 +44,7 @@ namespace MongoDB.Infrastructure.Internal
         private bool TryGet(IMongoClient client, string databaseName, out IMongoDatabase database)
         {
             database = _databases.Where(database => database is not null)
+                                 .Where(database => database.Client.Settings.Credential == client.Settings.Credential)
                                  .Where(database => database.Client.Settings.Servers.Count() == client.Settings.Servers.Count())
                                  .Where(database => database.Client.Settings.Servers.All(client.Settings.Servers.Contains))
                                  .Where(database => database.DatabaseNamespace.DatabaseName.Equals(databaseName, StringComparison.OrdinalIgnoreCase))

--- a/src/MongoDB.Infrastructure/Internal/MongoDbDatabaseManager.cs
+++ b/src/MongoDB.Infrastructure/Internal/MongoDbDatabaseManager.cs
@@ -44,6 +44,7 @@ namespace MongoDB.Infrastructure.Internal
         private bool TryGet(IMongoClient client, string databaseName, out IMongoDatabase database)
         {
             database = _databases.Where(database => database is not null)
+                                 .Where(database => database.Client.Settings.ToString() == client.Settings.ToString())
                                  .Where(database => database.Client.Settings.Servers.Count() == client.Settings.Servers.Count())
                                  .Where(database => database.Client.Settings.Servers.All(client.Settings.Servers.Contains))
                                  .Where(database => database.DatabaseNamespace.DatabaseName.Equals(databaseName, StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Hello Fernando, this PR is because for different client configuration a different client is needed.
There are cases like I declare different credentials for different databases, even in the same server, in general if I declare different settings, a new client should be created. I used the MongoClientSettings.ToString() because it returns all settings in a single string.

Let me know what do you think.

If you decide to merge do squash merge, I had some issues with my git commands, and I did 3 commits.