### PR TITLE
Bugfix/concurrency handling

### DIFF
--- a/src/MongoDB.Infrastructure/Internal/MongoDbThrottlingSemaphoreManager.cs
+++ b/src/MongoDB.Infrastructure/Internal/MongoDbThrottlingSemaphoreManager.cs
@@ -32,15 +32,9 @@ namespace MongoDB.Infrastructure.Internal
                 throw new ArgumentNullException(nameof(client), $"{nameof(client)} cannot be null.");
             }
 
-            if (TryGet(client, out IMongoDbThrottlingSemaphore semaphore))
-            {
-                return semaphore;
-            }
-
             var cluster = new MongoDbCluster(client.Settings.Servers);
-            _semaphores[cluster] = semaphore = _semaphoreFactory.Create(maximumNumberOfConcurrentRequests);
 
-            return semaphore;
+            return _semaphores.GetOrAdd(cluster, _ => _semaphoreFactory.Create(maximumNumberOfConcurrentRequests));
         }
 
         private bool TryGet(IMongoClient client, out IMongoDbThrottlingSemaphore semaphore)

--- a/src/MongoDB.Infrastructure/Internal/MongoDbThrottlingSemaphoreManager.cs
+++ b/src/MongoDB.Infrastructure/Internal/MongoDbThrottlingSemaphoreManager.cs
@@ -1,7 +1,6 @@
 ﻿using MongoDB.Driver;
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 
 namespace MongoDB.Infrastructure.Internal
 {
@@ -9,7 +8,6 @@ namespace MongoDB.Infrastructure.Internal
     {
         private readonly IMongoDbThrottlingSemaphoreFactory _semaphoreFactory;
         private readonly ConcurrentDictionary<string, IMongoDbThrottlingSemaphore> _semaphores;
-        private readonly object _lock = new object();
 
         private static readonly Lazy<MongoDbThrottlingSemaphoreManager> _factory = new(() =>
             new MongoDbThrottlingSemaphoreManager(), isThreadSafe: true);
@@ -32,31 +30,8 @@ namespace MongoDB.Infrastructure.Internal
             {
                 throw new ArgumentNullException(nameof(client), $"{nameof(client)} cannot be null.");
             }
-
-            // Use lock because the search TryGet is complex search and there is no way to do atomic search and Insert
-            lock (_lock)
-            {
-                if (TryGet(client, out IMongoDbThrottlingSemaphore semaphore))
-                {
-                    return semaphore;
-                }
-
-                var cluster = new MongoDbCluster(client.Settings.Servers);
-                _semaphores[cluster] = semaphore = _semaphoreFactory.Create(maximumNumberOfConcurrentRequests);
-                
-                return semaphore;
-            };            
-        }
-
-        private bool TryGet(IMongoClient client, out IMongoDbThrottlingSemaphore semaphore)
-        {
-            semaphore = _semaphores.ToArray()
-                                   .Where(semaphore => semaphore.Key is not null && semaphore.Value is not null)
-                                   .Where(semaphore => semaphore.Key == new MongoDbCluster(client.Settings.Servers))
-                                   .Select(semaphore => semaphore.Value)
-                                   .SingleOrDefault();
-
-            return semaphore is not null;
+            var lookupKey = new MongoDbCluster(client.Settings.Servers).ToString();
+            return _semaphores.GetOrAdd(lookupKey, _ => _semaphoreFactory.Create(maximumNumberOfConcurrentRequests));
         }
     }
 }

--- a/src/MongoDB.UnitOfWork/MongoDbUnitOfWork.cs
+++ b/src/MongoDB.UnitOfWork/MongoDbUnitOfWork.cs
@@ -123,15 +123,7 @@ namespace MongoDB.UnitOfWork
             string prefix)
         {
             var typeName = $"{prefix}.{objectType.FullName}";
-
-            if (!_repositories.TryGetValue(typeName, out var repository))
-            {
-                repository = repositoryFactory.Invoke(Context, objectType);
-
-                _repositories[typeName] = repository;
-            }
-
-            return repository;
+            return _repositories.GetOrAdd(typeName, _ => repositoryFactory.Invoke(Context, objectType));            
         }
 
         #endregion Private Methods


### PR DESCRIPTION
Fernando, I found certain cases where an operation can overwrite an existing value in the dictionary, which could cause issues if multiple threads are trying to add at the same time. The TryGetValue method and the assignment are not guaranteed to be atomic operations, meaning there is a race condition where two threads could enter simultaneously, and both may attempt to add a dictionary for the same key.

The case of MongoDbThrottlingSemaphoreManager.cs need to be handled using a lock since the search is not a simple lockup.

Let me know what do u think.