### PR TITLE
Release: Version 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,32 +12,32 @@ If you like or are using this project to learn or start your solution, please gi
 
  | Package | NuGet |
  | ------- | ------- |
- | MongoDB.Data.Infrastructure.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure.Abstractions/1.7.2) |
- | MongoDB.Data.QueryBuilder.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder.Abstractions/1.7.2) |
- | MongoDB.Data.Repository.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Repository.Abstractions/1.7.2) |
- | MongoDB.Data.UnitOfWork.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork.Abstractions/1.7.2) |
+ | MongoDB.Data.Infrastructure.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure.Abstractions/1.8.0) |
+ | MongoDB.Data.QueryBuilder.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder.Abstractions/1.8.0) |
+ | MongoDB.Data.Repository.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Repository.Abstractions/1.8.0) |
+ | MongoDB.Data.UnitOfWork.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork.Abstractions/1.8.0) |
  | ------- | ------- |
- | MongoDB.Data.Generators | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Generators)](https://www.nuget.org/packages/MongoDB.Data.Generators/1.7.2) |
- | MongoDB.Data.Infrastructure | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure/1.7.2) |
- | MongoDB.Data.QueryBuilder | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder/1.7.2) |
- | MongoDB.Data.Repository | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository)](https://www.nuget.org/packages/MongoDB.Data.Repository/1.7.2) |
- | MongoDB.Data.UnitOfWork | [![Nuget](https://img.shields.io/badge/nuget-v1.7.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork/1.7.2) |
+ | MongoDB.Data.Generators | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Generators)](https://www.nuget.org/packages/MongoDB.Data.Generators/1.8.0) |
+ | MongoDB.Data.Infrastructure | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure/1.8.0) |
+ | MongoDB.Data.QueryBuilder | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder/1.8.0) |
+ | MongoDB.Data.Repository | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository)](https://www.nuget.org/packages/MongoDB.Data.Repository/1.8.0) |
+ | MongoDB.Data.UnitOfWork | [![Nuget](https://img.shields.io/badge/nuget-v1.8.0-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork/1.8.0) |
 
 ## Installation
 
 MongoDB.DataAccess is available on Nuget.
 
 ```
-Install-Package MongoDB.Data.Infrastructure.Abstractions -Version 1.7.2
-Install-Package MongoDB.Data.QueryBuilder.Abstractions -Version 1.7.2
-Install-Package MongoDB.Data.Repository.Abstractions -Version 1.7.2
-Install-Package MongoDB.Data.UnitOfWork.Abstractions -Version 1.7.2
+Install-Package MongoDB.Data.Infrastructure.Abstractions -Version 1.8.0
+Install-Package MongoDB.Data.QueryBuilder.Abstractions -Version 1.8.0
+Install-Package MongoDB.Data.Repository.Abstractions -Version 1.8.0
+Install-Package MongoDB.Data.UnitOfWork.Abstractions -Version 1.8.0
 
-Install-Package MongoDB.Data.Generators -Version 1.7.2
-Install-Package MongoDB.Data.Infrastructure -Version 1.7.2
-Install-Package MongoDB.Data.QueryBuilder -Version 1.7.2
-Install-Package MongoDB.Data.Repository -Version 1.7.2
-Install-Package MongoDB.Data.UnitOfWork -Version 1.7.2
+Install-Package MongoDB.Data.Generators -Version 1.8.0
+Install-Package MongoDB.Data.Infrastructure -Version 1.8.0
+Install-Package MongoDB.Data.QueryBuilder -Version 1.8.0
+Install-Package MongoDB.Data.Repository -Version 1.8.0
+Install-Package MongoDB.Data.UnitOfWork -Version 1.8.0
 ```
 
 **P.S.: MongoDB.Data.UnitOfWork depends on the other packages, so installing this package is enough.**

--- a/samples/MongoDB.Data/MongoDB.Data.csproj
+++ b/samples/MongoDB.Data/MongoDB.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/samples/MongoDB.Models/MongoDB.Models.csproj
+++ b/samples/MongoDB.Models/MongoDB.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Generators/MongoDB.Generators.csproj
+++ b/src/MongoDB.Generators/MongoDB.Generators.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -16,12 +16,12 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;IdGenerators;Id Generators;id-generators</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
+++ b/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -17,12 +17,12 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
+++ b/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
+    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
+++ b/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
+++ b/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository.Abstractions/IMongoDbSyncRepository.cs
+++ b/src/MongoDB.Repository.Abstractions/IMongoDbSyncRepository.cs
@@ -3,6 +3,7 @@ using MongoDB.Driver.Linq;
 using MongoDB.QueryBuilder;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace MongoDB.Repository
@@ -46,7 +47,7 @@ namespace MongoDB.Repository
         object ReplaceOne(Expression<Func<T, bool>> predicate, T entity, ReplaceOptions options = null);
         object DeleteOne(Expression<Func<T, bool>> predicate, DeleteOptions options = null);
         object DeleteMany(Expression<Func<T, bool>> predicate, DeleteOptions options = null);
-        IMongoQueryable<T> ToQueryable(IMongoDbQuery<T> query);
-        IMongoQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query);
+        IQueryable<T> ToQueryable(IMongoDbQuery<T> query);
+        IQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query);
     }
 }

--- a/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
+++ b/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -17,12 +17,12 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MongoDB.Repository/MongoDB.Repository.csproj
+++ b/src/MongoDB.Repository/MongoDB.Repository.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository/MongoDbRepository.cs
+++ b/src/MongoDB.Repository/MongoDbRepository.cs
@@ -648,7 +648,7 @@ namespace MongoDB.Repository
             }
         }
 
-        public IMongoQueryable<T> ToQueryable(IMongoDbQuery<T> query)
+        public IQueryable<T> ToQueryable(IMongoDbQuery<T> query)
         {
             IMongoDbMultipleResultQuery<T> multipleResultQuery = null;
 
@@ -696,10 +696,10 @@ namespace MongoDB.Repository
                 queryable = queryable.Select(query.Selector);
             }
 
-            return (IMongoQueryable<T>)queryable;
+            return queryable;
         }
 
-        public IMongoQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query)
+        public IQueryable<TResult> ToQueryable<TResult>(IMongoDbQuery<T, TResult> query)
         {
             IMongoDbMultipleResultQuery<T, TResult> multipleResultQuery = null;
 
@@ -742,7 +742,7 @@ namespace MongoDB.Repository
                 queryable = queryable.Page(multipleResultQuery.Paging);
             }
 
-            return (IMongoQueryable<TResult>)queryable.Select(query.Selector);
+            return queryable.Select(query.Selector);
         }
 
         #endregion ISyncRepository<T> Members

--- a/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
+++ b/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
+++ b/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.7.2</Version>
+    <Version>1.8.0</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- Removed .netstandard 2.0 target framework;
- Migrated MongoDB.Driver to version 3.0.0;
- Updated dependencies;
- Bumped library version to 1.8.0.