### PR TITLE
Release: Version 1.8.2 + Use ActivatorUtilities.CreateInstance to Support Proper Dependency Injection 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Fernando Luiz de Lima
+Copyright (c) 2025 Fernando Luiz de Lima
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -10,34 +10,34 @@ If you like or are using this project to learn or start your solution, please gi
 
 [![build-and-publish Workflow Status](https://github.com/ffernandolima/mongo-db-data-access/actions/workflows/build-and-publish.yml/badge.svg?branch=main)](https://github.com/ffernandolima/mongo-db-data-access/actions/workflows/build-and-publish.yml/branch=main)
 
- | Package | NuGet |
- | ------- | ------- |
- | MongoDB.Data.Infrastructure.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure.Abstractions/1.8.1) |
- | MongoDB.Data.QueryBuilder.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder.Abstractions/1.8.1) |
- | MongoDB.Data.Repository.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Repository.Abstractions/1.8.1) |
- | MongoDB.Data.UnitOfWork.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork.Abstractions/1.8.1) |
- | ------- | ------- |
- | MongoDB.Data.Generators | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Generators)](https://www.nuget.org/packages/MongoDB.Data.Generators/1.8.1) |
- | MongoDB.Data.Infrastructure | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure/1.8.1) |
- | MongoDB.Data.QueryBuilder | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder/1.8.1) |
- | MongoDB.Data.Repository | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository)](https://www.nuget.org/packages/MongoDB.Data.Repository/1.8.1) |
- | MongoDB.Data.UnitOfWork | [![Nuget](https://img.shields.io/badge/nuget-v1.8.1-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork/1.8.1) |
+| Package                                  | NuGet                                                                                                                                                                                                                        |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MongoDB.Data.Infrastructure.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure.Abstractions/1.8.2) |
+| MongoDB.Data.QueryBuilder.Abstractions   | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder.Abstractions/1.8.2)     |
+| MongoDB.Data.Repository.Abstractions     | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Repository.Abstractions/1.8.2)         |
+| MongoDB.Data.UnitOfWork.Abstractions     | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork.Abstractions/1.8.2)         |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MongoDB.Data.Generators                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Generators)](https://www.nuget.org/packages/MongoDB.Data.Generators/1.8.2)                                   |
+| MongoDB.Data.Infrastructure              | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure/1.8.2)                           |
+| MongoDB.Data.QueryBuilder                | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder/1.8.2)                               |
+| MongoDB.Data.Repository                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository)](https://www.nuget.org/packages/MongoDB.Data.Repository/1.8.2)                                   |
+| MongoDB.Data.UnitOfWork                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.2-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork/1.8.2)                                   |
 
 ## Installation
 
 MongoDB.DataAccess is available on Nuget.
 
 ```
-Install-Package MongoDB.Data.Infrastructure.Abstractions -Version 1.8.1
-Install-Package MongoDB.Data.QueryBuilder.Abstractions -Version 1.8.1
-Install-Package MongoDB.Data.Repository.Abstractions -Version 1.8.1
-Install-Package MongoDB.Data.UnitOfWork.Abstractions -Version 1.8.1
+Install-Package MongoDB.Data.Infrastructure.Abstractions -Version 1.8.2
+Install-Package MongoDB.Data.QueryBuilder.Abstractions -Version 1.8.2
+Install-Package MongoDB.Data.Repository.Abstractions -Version 1.8.2
+Install-Package MongoDB.Data.UnitOfWork.Abstractions -Version 1.8.2
 
-Install-Package MongoDB.Data.Generators -Version 1.8.1
-Install-Package MongoDB.Data.Infrastructure -Version 1.8.1
-Install-Package MongoDB.Data.QueryBuilder -Version 1.8.1
-Install-Package MongoDB.Data.Repository -Version 1.8.1
-Install-Package MongoDB.Data.UnitOfWork -Version 1.8.1
+Install-Package MongoDB.Data.Generators -Version 1.8.2
+Install-Package MongoDB.Data.Infrastructure -Version 1.8.2
+Install-Package MongoDB.Data.QueryBuilder -Version 1.8.2
+Install-Package MongoDB.Data.Repository -Version 1.8.2
+Install-Package MongoDB.Data.UnitOfWork -Version 1.8.2
 ```
 
 **P.S.: MongoDB.Data.UnitOfWork depends on the other packages, so installing this package is enough.**

--- a/src/MongoDB.Generators/MongoDB.Generators.csproj
+++ b/src/MongoDB.Generators/MongoDB.Generators.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;IdGenerators;Id Generators;id-generators</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
+++ b/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Infrastructure/Extensions/MongoDbInfrastructureServiceCollectionExtensions.cs
+++ b/src/MongoDB.Infrastructure/Extensions/MongoDbInfrastructureServiceCollectionExtensions.cs
@@ -58,7 +58,7 @@ namespace MongoDB.Infrastructure.Extensions
                             databaseSettings,
                             dbContextOptions ?? CreateDbContextOptions<TService, TImplementation>(clientSettings));
 
-                        var context = ActivatorUtilities.CreateInstance(
+                        var context = (TImplementation)ActivatorUtilities.CreateInstance(
                             provider,
                             typeof(TImplementation),
                             connection.Client,

--- a/src/MongoDB.Infrastructure/Extensions/MongoDbInfrastructureServiceCollectionExtensions.cs
+++ b/src/MongoDB.Infrastructure/Extensions/MongoDbInfrastructureServiceCollectionExtensions.cs
@@ -58,7 +58,8 @@ namespace MongoDB.Infrastructure.Extensions
                             databaseSettings,
                             dbContextOptions ?? CreateDbContextOptions<TService, TImplementation>(clientSettings));
 
-                        var context = (TImplementation)Activator.CreateInstance(
+                        var context = ActivatorUtilities.CreateInstance(
+                            provider,
                             typeof(TImplementation),
                             connection.Client,
                             connection.Database,

--- a/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
+++ b/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
+++ b/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
+++ b/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
+++ b/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository/MongoDB.Repository.csproj
+++ b/src/MongoDB.Repository/MongoDB.Repository.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
+++ b/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
+++ b/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR replaces the usage of `Activator.CreateInstance` with `ActivatorUtilities.CreateInstance` to properly handle scenarios where dependencies need to be injected by the DI container.

Changes:

- Replaced `Activator.CreateInstance` with `ActivatorUtilities.CreateInstance`.
- Verified that object creation works correctly both when dependencies are required and when no dependencies are needed.

This PR will also release a new version of the library (1.8.2).