### PR TITLE
Release: Version 1.8.4 + Fix MongoDbContext double instantiation by reusing keyed registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,32 +12,32 @@ If you like or are using this project to learn or start your solution, please gi
 
 | Package                                  | NuGet                                                                                                                                                                                                                        |
 |------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| MongoDB.Data.Infrastructure.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure.Abstractions/1.8.3) |
-| MongoDB.Data.QueryBuilder.Abstractions   | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder.Abstractions/1.8.3)     |
-| MongoDB.Data.Repository.Abstractions     | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Repository.Abstractions/1.8.3)         |
-| MongoDB.Data.UnitOfWork.Abstractions     | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork.Abstractions/1.8.3)         |
+| MongoDB.Data.Infrastructure.Abstractions | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure.Abstractions/1.8.4) |
+| MongoDB.Data.QueryBuilder.Abstractions   | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder.Abstractions/1.8.4)     |
+| MongoDB.Data.Repository.Abstractions     | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.Repository.Abstractions/1.8.4)         |
+| MongoDB.Data.UnitOfWork.Abstractions     | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork.Abstractions)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork.Abstractions/1.8.4)         |
 |------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| MongoDB.Data.Generators                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Generators)](https://www.nuget.org/packages/MongoDB.Data.Generators/1.8.3)                                   |
-| MongoDB.Data.Infrastructure              | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure/1.8.3)                           |
-| MongoDB.Data.QueryBuilder                | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder/1.8.3)                               |
-| MongoDB.Data.Repository                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository)](https://www.nuget.org/packages/MongoDB.Data.Repository/1.8.3)                                   |
-| MongoDB.Data.UnitOfWork                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.3-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork/1.8.3)                                   |
+| MongoDB.Data.Generators                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Generators)](https://www.nuget.org/packages/MongoDB.Data.Generators/1.8.4)                                   |
+| MongoDB.Data.Infrastructure              | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Infrastructure)](https://www.nuget.org/packages/MongoDB.Data.Infrastructure/1.8.4)                           |
+| MongoDB.Data.QueryBuilder                | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.QueryBuilder)](https://www.nuget.org/packages/MongoDB.Data.QueryBuilder/1.8.4)                               |
+| MongoDB.Data.Repository                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.Repository)](https://www.nuget.org/packages/MongoDB.Data.Repository/1.8.4)                                   |
+| MongoDB.Data.UnitOfWork                  | [![Nuget](https://img.shields.io/badge/nuget-v1.8.4-blue) ![Nuget](https://img.shields.io/nuget/dt/MongoDB.Data.UnitOfWork)](https://www.nuget.org/packages/MongoDB.Data.UnitOfWork/1.8.4)                                   |
 
 ## Installation
 
 MongoDB.DataAccess is available on Nuget.
 
 ```
-Install-Package MongoDB.Data.Infrastructure.Abstractions -Version 1.8.3
-Install-Package MongoDB.Data.QueryBuilder.Abstractions -Version 1.8.3
-Install-Package MongoDB.Data.Repository.Abstractions -Version 1.8.3
-Install-Package MongoDB.Data.UnitOfWork.Abstractions -Version 1.8.3
+Install-Package MongoDB.Data.Infrastructure.Abstractions -Version 1.8.4
+Install-Package MongoDB.Data.QueryBuilder.Abstractions -Version 1.8.4
+Install-Package MongoDB.Data.Repository.Abstractions -Version 1.8.4
+Install-Package MongoDB.Data.UnitOfWork.Abstractions -Version 1.8.4
 
-Install-Package MongoDB.Data.Generators -Version 1.8.3
-Install-Package MongoDB.Data.Infrastructure -Version 1.8.3
-Install-Package MongoDB.Data.QueryBuilder -Version 1.8.3
-Install-Package MongoDB.Data.Repository -Version 1.8.3
-Install-Package MongoDB.Data.UnitOfWork -Version 1.8.3
+Install-Package MongoDB.Data.Generators -Version 1.8.4
+Install-Package MongoDB.Data.Infrastructure -Version 1.8.4
+Install-Package MongoDB.Data.QueryBuilder -Version 1.8.4
+Install-Package MongoDB.Data.Repository -Version 1.8.4
+Install-Package MongoDB.Data.UnitOfWork -Version 1.8.4
 ```
 
 **P.S.: MongoDB.Data.UnitOfWork depends on the other packages, so installing this package is enough.**

--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ services.AddMongoDbContext<IMongoDbContext, BloggingContext>(
 
 // Register the UnitOfWork
 services.AddMongoDbUnitOfWork<BloggingContext>();
+
+// Or
+services.AddMongoDbUnitOfWork<BloggingContext>("BloggingContext - TenantA");
+services.AddMongoDbUnitOfWork<BloggingContext>("BloggingContext - TenantB");
 ```
 
 After that, use the structure in your code like that:

--- a/src/MongoDB.Generators/MongoDB.Generators.csproj
+++ b/src/MongoDB.Generators/MongoDB.Generators.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;IdGenerators;Id Generators;id-generators</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
+++ b/src/MongoDB.Infrastructure.Abstractions/MongoDB.Infrastructure.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
+++ b/src/MongoDB.Infrastructure/MongoDB.Infrastructure.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Infrastructure</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
+++ b/src/MongoDB.QueryBuilder.Abstractions/MongoDB.QueryBuilder.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
+++ b/src/MongoDB.QueryBuilder/MongoDB.QueryBuilder.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;QueryBuilder;Query Builder;query-builder</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
+++ b/src/MongoDB.Repository.Abstractions/MongoDB.Repository.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.Repository/MongoDB.Repository.csproj
+++ b/src/MongoDB.Repository/MongoDB.Repository.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;Repository</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
+++ b/src/MongoDB.UnitOfWork.Abstractions/MongoDB.UnitOfWork.Abstractions.csproj
@@ -17,7 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work;Abstractions</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
+++ b/src/MongoDB.UnitOfWork/MongoDB.UnitOfWork.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>MongoDB;Mongo DB;mongo-db;Data;UnitOfWork;Unit Of Work;unit-of-work</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/MongoDB.UnitOfWork/MongoDbUnitOfWorkFactory.cs
+++ b/src/MongoDB.UnitOfWork/MongoDbUnitOfWorkFactory.cs
@@ -1,6 +1,5 @@
 ﻿using MongoDB.Infrastructure;
 using System;
-using System.Linq;
 
 namespace MongoDB.UnitOfWork
 {
@@ -20,17 +19,11 @@ namespace MongoDB.UnitOfWork
                 throw new ArgumentException($"{nameof(dbContextId)} cannot be null or whitespace.", nameof(dbContextId));
             }
 
-            var resolvedContext =
-                _factory.GetKeyedService<T>(dbContextId) ??
-                _factory.GetServices<T>()?.SingleOrDefault(
-                    context => string.Equals(
-                        context?.Options?.DbContextId,
-                        dbContextId,
-                        StringComparison.OrdinalIgnoreCase));
+            var context = _factory.GetKeyedService<T>(dbContextId);
 
             var unitOfWork = (IMongoDbUnitOfWork<T>)Activator.CreateInstance(
                 typeof(MongoDbUnitOfWork<T>),
-                resolvedContext,
+                context,
                 _factory);
 
             return unitOfWork;


### PR DESCRIPTION
This PR Closes #26 

Previously, `keyed` and `unkeyed` `MongoDbContext` registrations created separate instances, 
causing issues in scoped and singleton lifetimes. This change ensures the instance is 
created only in the `keyed` registration and reused by the `unkeyed` one, maintaining correct behavior.

This PR will also release a new version of the library (1.8.4).